### PR TITLE
feat: Implement multi-distro testing for install.sh using QEMU

### DIFF
--- a/.github/workflows/qemu.yml
+++ b/.github/workflows/qemu.yml
@@ -47,118 +47,174 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y python3 python3-pip git openssl
 
+      - name: Install QEMU utilities and sshpass
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-utils sshpass cloud-utils
+
       - name: Make install script executable
         run: chmod +x scripts/install.sh
 
-  test-installation:
-    needs: setup-environment
+  test_on_distros:
     runs-on: ubuntu-latest
+    needs: setup-environment
     strategy:
+      fail-fast: false # Continue testing other distros even if one fails
       matrix:
         include:
-          # Basic combinations
-          - name: minimal
-            env: production
-            email: ""
-            password: ""
-            api_domain: ""
-            app_domain: ""
-          - name: email-only
-            env: production
-            email: admin@nixopus.local
-            password: ""
-            api_domain: ""
-            app_domain: ""
-          - name: password-only
-            env: production
-            email: ""
-            password: Nixopus@123!Secure
-            api_domain: ""
-            app_domain: ""
-          - name: email-password
-            env: production
-            email: admin@nixopus.local
-            password: Nixopus@123!Secure
-            api_domain: ""
-            app_domain: ""
-
-          # Domain combinations
-          - name: api-domain-only
-            env: production
-            email: admin@nixopus.local
-            password: Nixopus@123!Secure
-            api_domain: api.nixopus.local
-            app_domain: ""
-          - name: app-domain-only
-            env: production
-            email: admin@nixopus.local
-            password: Nixopus@123!Secure
-            api_domain: ""
-            app_domain: app.nixopus.local
-          - name: both-domains
-            env: production
-            email: admin@nixopus.local
-            password: Nixopus@123!Secure
-            api_domain: api.nixopus.local
-            app_domain: app.nixopus.local
-
-          # # Staging combinations
-          # - name: staging-minimal
-          #   env: staging
-          #   email: ""
-          #   password: ""
-          #   api_domain: ""
-          #   app_domain: ""
-          # - name: staging-email-password
-          #   env: staging
-          #   email: admin@nixopus.local
-          #   password: Nixopus@123!Secure
-          #   api_domain: ""
-          #   app_domain: ""
-          # - name: staging-api-domain-only
-          #   env: staging
-          #   email: admin@nixopus.local
-          #   password: Nixopus@123!Secure
-          #   api_domain: api.staging.nixopus.local
-          #   app_domain: ""
-          # - name: staging-app-domain-only
-          #   env: staging
-          #   email: admin@nixopus.local
-          #   password: Nixopus@123!Secure
-          #   api_domain: ""
-          #   app_domain: app.staging.nixopus.local
-          # - name: staging-both-domains
-          #   env: staging
-          #   email: admin@nixopus.local
-          #   password: Nixopus@123!Secure
-          #   api_domain: api.staging.nixopus.local
-          #   app_domain: app.staging.nixopus.local
-
+          - distro: debian11
+            image_url: https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-amd64.qcow2
+            username: debian # Typical default username for Debian cloud images
+          - distro: debian12
+            image_url: https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2
+            username: debian
+          - distro: ubuntu2004
+            image_url: https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.qcow2
+            username: ubuntu # Typical default username for Ubuntu cloud images
+          - distro: ubuntu2204
+            image_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.qcow2
+            username: ubuntu
+          - distro: fedora_latest
+            image_url: https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2
+            username: fedora # Typical default username for Fedora cloud images
+          - distro: almalinux_latest
+            image_url: https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2
+            username: almalinux # Typical default username for AlmaLinux cloud images
+          - distro: archlinux_latest
+            image_url: https://geo.mirror.pkgbuild.com/images/latest/Arch-Linux-x86_64-cloudimg.qcow2
+            username: arch # Typical default username for Arch Linux cloud images
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Run install script
+      - name: Debug Info
         run: |
-          cmd="./scripts/install.sh"
-          
-          if [ -n "${{ matrix.email }}" ]; then
-            cmd="$cmd --email=${{ matrix.email }}"
+          echo "Starting test for ${{ matrix.distro }}"
+          echo "Image URL: ${{ matrix.image_url }}"
+          echo "Username: ${{ matrix.username }}"
+          echo "Runner temp directory: ${{ runner.temp }}"
+
+      - name: Download OS Image
+        run: |
+          mkdir -p ${{ runner.temp }}/images
+          wget -O ${{ runner.temp }}/images/${{ matrix.distro }}.qcow2 ${{ matrix.image_url }}
+          ls -lh ${{ runner.temp }}/images/
+
+      - name: Generate SSH key for VM access
+        run: |
+          ssh-keygen -t rsa -b 2048 -N "" -f ~/.ssh/id_rsa
+          echo "Public key:"
+          cat ~/.ssh/id_rsa.pub
+          # Ensure ssh-agent is running (useful for scp/ssh)
+          eval "$(ssh-agent -s)"
+          ssh-add ~/.ssh/id_rsa
+
+      - name: Create cloud-init ISO
+        id: cloud_init
+        run: |
+          mkdir -p ${{ runner.temp }}/cloud-init
+          KEY_PUB=$(cat ~/.ssh/id_rsa.pub) # We'll generate this key in a prior step
+          # Basic cloud-init: just add the public key
+          cat <<EOF > ${{ runner.temp }}/cloud-init/user-data
+          #cloud-config
+          users:
+            - name: ${{ matrix.username }}
+              ssh_authorized_keys:
+                - ${KEY_PUB}
+              sudo: ['ALL=(ALL) NOPASSWD:ALL']
+          EOF
+          cat <<EOF > ${{ runner.temp }}/cloud-init/meta-data
+          instance-id: iid-local01
+          local-hostname: ${{ matrix.distro }}-vm
+          EOF
+          sudo cloud-localds -v ${{ runner.temp }}/cloud-init/${{ matrix.distro }}-cloud-init.iso ${{ runner.temp }}/cloud-init/user-data ${{ runner.temp }}/cloud-init/meta-data
+          echo "iso_path=${{ runner.temp }}/cloud-init/${{ matrix.distro }}-cloud-init.iso" >> $GITHUB_OUTPUT
+          ls -lh ${{ runner.temp }}/cloud-init/
+
+      - name: Start QEMU VM
+        run: |
+          # Port for SSH forwarding
+          SSH_PORT=$(( ( RANDOM % (65535-1024) ) + 1024 ))
+          echo "Using host port $SSH_PORT for SSH to VM"
+          echo "SSH_PORT=$SSH_PORT" >> $GITHUB_ENV
+
+          sudo qemu-system-x86_64 \
+            -m 2048 \
+            -smp 2 \
+            -nographic \
+            -drive file=${{ runner.temp }}/images/${{ matrix.distro }}.qcow2,format=qcow2,if=virtio \
+            -drive file=${{ steps.cloud_init.outputs.iso_path }},media=cdrom,if=virtio \
+            -netdev user,id=net0,hostfwd=tcp::${SSH_PORT}-:22 \
+            -device virtio-net-pci,netdev=net0 \
+            -pidfile ${{ runner.temp }}/qemu_${{ matrix.distro }}.pid \
+            -daemonize
+          echo "QEMU VM started for ${{ matrix.distro }}."
+
+      - name: Wait for SSH to be available
+        run: |
+          echo "Waiting for SSH on port ${{ env.SSH_PORT }}..."
+          for i in {1..60}; do
+            if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -p ${{ env.SSH_PORT }} ${{ matrix.username }}@localhost "echo VM SSH is up"; then
+              echo "SSH connection successful."
+              break
+            fi
+            echo "Attempt $i: SSH not ready yet, sleeping 5s..."
+            sleep 5
+          done
+          # Final check, fail if still not up
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=5 -p ${{ env.SSH_PORT }} ${{ matrix.username }}@localhost "echo VM SSH is verified"
+
+      - name: Copy install script to VM
+        run: |
+          scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -P ${{ env.SSH_PORT }} \
+            ./scripts/install.sh \
+            ${{ matrix.username }}@localhost:/tmp/install.sh
+
+      - name: Make install script executable and run it
+        run: |
+          echo "Executing install script on VM for ${{ matrix.distro }} via SSH..."
+          ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p ${{ env.SSH_PORT }} ${{ matrix.username }}@localhost << 'EOF'
+            chmod +x /tmp/install.sh
+            echo "Running /tmp/install.sh..."
+            # Execute the script, capturing output and exit code
+            sudo /tmp/install.sh > /tmp/install_stdout.log 2> /tmp/install_stderr.log
+            SCRIPT_EXIT_CODE=$?
+
+            echo "" # Newline for cleaner log separation
+            echo "--- STDOUT from install.sh ---"
+            cat /tmp/install_stdout.log
+            echo "--- STDERR from install.sh ---"
+            cat /tmp/install_stderr.log
+            echo "------------------------------"
+            echo "INSTALL_SCRIPT_EXIT_CODE: ${SCRIPT_EXIT_CODE}"
+
+            # Clean up log files on VM
+            rm -f /tmp/install_stdout.log /tmp/install_stderr.log
+
+            exit ${SCRIPT_EXIT_CODE}
+          EOF
+          # The GitHub Actions step will fail if ssh returns a non-zero exit code.
+
+      - name: Cleanup VM specific files # optional, good practice
+        if: always() # Run even if previous steps fail
+        run: |
+          echo "Cleaning up for ${{ matrix.distro }}"
+          QEMU_PID_FILE=${{ runner.temp }}/qemu_${{ matrix.distro }}.pid
+          if [ -f "$QEMU_PID_FILE" ]; then
+            QEMU_PID=$(cat $QEMU_PID_FILE)
+            if [ -n "$QEMU_PID" ]; then
+              echo "Attempting to kill QEMU process with PID $QEMU_PID..."
+              sudo kill $QEMU_PID || echo "Failed to kill QEMU PID $QEMU_PID (maybe already stopped?)"
+              # Allow some time for process to terminate
+              sleep 2
+              # Optionally, check if process is still alive and force kill: sudo kill -9 $QEMU_PID
+            fi
+            rm -f $QEMU_PID_FILE
+          else
+            echo "QEMU PID file not found: $QEMU_PID_FILE"
           fi
           
-          if [ -n "${{ matrix.password }}" ]; then
-            cmd="$cmd --password=${{ matrix.password }}"
-          fi
-          
-          if [ -n "${{ matrix.api_domain }}" ]; then
-            cmd="$cmd --api-domain=${{ matrix.api_domain }}"
-          fi
-          
-          if [ -n "${{ matrix.app_domain }}" ]; then
-            cmd="$cmd --app-domain=${{ matrix.app_domain }}"
-          fi
-          
-          cmd="$cmd --env=${{ matrix.env }}"
-          
-          echo "Running command: $cmd"
-          sudo $cmd
+          # Existing cleanup
+          rm -f ${{ runner.temp }}/images/${{ matrix.distro }}.qcow2
+          rm -f ${{ steps.cloud_init.outputs.iso_path }}
+          # Be careful with removing SSH keys if they are reused across matrix jobs (they are not here)


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow in .github/workflows/qemu.yml to test your `scripts/install.sh` across a range of Linux distributions. The workflow was significantly refactored from its previous form.

Key features:
- Uses a matrix strategy to run tests on Debian 11/12, Ubuntu 20.04/22.04, Fedora (latest), AlmaLinux (latest), and Arch Linux (latest).
- For each distribution:
  - Downloads the respective official cloud image (QCOW2 format).
  - Generates an SSH key pair on-the-fly.
  - Creates a cloud-init ISO to configure the VM user and inject the public SSH key for passwordless SSH access.
  - Boots the VM using QEMU in headless mode with network port forwarding for SSH.
  - Waits for the VM's SSH service to become available.
  - Copies your `scripts/install.sh` into the VM.
  - Executes `scripts/install.sh` within the VM.
- Captures and displays the stdout, stderr, and exit code of your `install.sh` script from each VM, ensuring clear reporting of success or failure per distribution.
- Implements QEMU process management using PID files for more reliable cleanup, ensuring QEMU processes are terminated after each test run.
- The `setup-environment` job now installs `qemu-utils`, `sshpass`, and `cloud-utils` to support these operations.

This new testing pipeline will help you identify compatibility issues with your `install.sh` across different Linux environments proactively.